### PR TITLE
Improved gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,49 @@
+# Node stuff
 node_modules
 .temp
 .cache
+
+# Windows shortcuts
+.lnk
+
+# Standard ignores based on https://gist.github.com/octocat/9257657
+
+###################
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+############
+# Packages #
+############
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+#######################
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+#######################
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
To reduce the chances of cruft being included in PRs and to improve the UX for committers I've updated the gitignore to exclude some common announces.

Used this list of generic ignores as a basis: ttps://gist.github.com/octocat/9257657