### PR TITLE
Feat framing overlays added to v1.1.0

### DIFF
--- a/docs/v1.1.0-rc.md
+++ b/docs/v1.1.0-rc.md
@@ -10,6 +10,7 @@ description: Official OCA specification
 
 - Introduce Credential Overlay
 - Introduce Form Overlay
+- Introduce Framing Overlays
 
 
 ## Introduction
@@ -598,6 +599,175 @@ Base that need protecting against unwarranted disclosure. For example, data that
 requires protection for legal or ethical reasons, personal privacy, or
 proprietary considerations.
 
+### Framing overlays
+
+Concepts, or the idea of something, can be codified and expressed in different types of controlled vocabularies such as glossaries, taxonomies and ontologies. These controlled vocabularies are often the result of a community coming together to define a shared set of terms, definitions and their relationships to help with communal understanding.
+
+To connect into these larger concepts OCA uses framing and framing overlays where different parts of a schema (e.g. attribute names) can be connected to a term in a specific controlled vocabulary. Framing can help describe what data is being collected, how it maps to other concepts, and ultimately how data can be connected to other knowledge.
+
+Where a schema provides a systemic blueprint for structuring concrete objects, a frame provides an epistemic blueprint for representing abstract concepts.
+
+Connecting an attribute, entry code, or unit to a term in a controlled vocabulary requires the nature of the relationship to be documented. Overlays Capture Architecture uses the [Simple Standard for Sharing Ontological Mappings](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9216545/) (SSSOM) ontology to add context to framings, such as are two terms equivalent or only closely related and what is the nature of that relationship? By describing how the different terms are specifically related means that framings can be precise.
+
+For framing overlays, OCA uses the four required SSSOM mapping elements. Any additional SSSOM metadata could be supplied external to OCA in other documentation. For OCA the naming conventions are as follows:
+
+|OCA|SSSOM|
+|---|---|
+|attribute/unit/entry code term used in OCA|subject_id|
+|term_id|object_id|
+|predicate_id|predicate_id|
+|framing_justification|matching_justification|
+
+When using framing in a schema multiple framing overlays are allowed and each framing overlay is specific for a single source being mapped to. The external concept must be described by sufficient cataloging information provided within the framing overlay so that users can know that they are accessing the correct external concept.
+
+The following four pieces of metadata will correctly identify external resources (e.g. the controlled vocabulary). Only `frame_id` is required.
+
+1. `frame_id`: Identifier of resource (SAIDs, DOIs, PURLs, or common names e.g. UCUM)
+2. `frame_label`: Label of resource (e.g. Unified Code for Units of Measure)
+3. `frame_location`: Location of resource (e.g. https://ucum.org/)
+4. `frame_version`: Resource version (e.g. 2.1).
+
+#### Attribute Framing Overlay
+
+Attribute Framing Overlays focus on the attributes used in schemas, mapping them to framing terms. Each attribute can have one or more framing terms, such as SKOS, indicating the mapping's degree of similarity or exactness. This allows a nuanced understanding of how schema attributes relate to broader ontological concepts.
+
+There can be multiple attribute framing overlays within a single bundle, but each framing overlay is specific for one external context source (such as a single ontology or vocabulary aka `frame_id`).  There can be only one overlay per unique `frame_id`. 
+
+In the attribute framing overlay, for each attribute (which must be unique in the schema) there can be zero or more `attribute_framing` terms. 
+
+For each attribute there can only be one skos:exactMatch, but there may be additional framing terms for the same attribute (e.g. skos:closeMatch). Unlike attribute to attribute mapping, attribute to concept mapping can be one to many with different levels of matching (e.g. different skos terms). See example below (albumin concentration).
+
+```json
+{
+  "capture_base": "Etszl9LgLUjllI950rd2lO6rF5-BP_jGzXGBPkFZCZFA",
+  "type": "spec/overlays/attribute_framing/1.0",
+  "framing_metadata": {
+    "frame_id": "SNOMEDCT",
+    "frame_label": "Systematized Nomenclature of Medicine Clinical Terms",
+    "frame_location": "https://bioportal.bioontology.org/ontologies/SNOMEDCT",
+    "frame_version": "2023AA"
+  },
+  "attribute_framing": {
+    "Albumin_concentration": {
+      "http://purl.bioontology.org/ontology/SNOMEDCT/365801005": {
+        "predicate_id": "skos:exactMatch",
+        "framing_justification": "semapv:ManualMappingCuration"
+      },
+      "http://purl.bioontology.org/ontology/SNOMEDCT/365799007": {
+        "predicate_id": "skos:broadMatch",
+        "framing_justification": "semapv:ManualMappingCuration"
+      }
+    },
+    "Glucose_concentration": {
+      "http://purl.bioontology.org/ontology/SNOMEDCT/365811003": {
+        "predicate_id": "skos:exactMatch",
+        "framing_justification": "semapv:ManualMappingCuration"
+      }
+    }
+  }
+}
+```
+
+#### Entry Code Framing Overlay
+
+Entry Code Framing Overlays focus on the entry codes used in schemas, mapping them to terms in external ontologies supporting detailed and precise data categorization. Like attribute framings, each entry code can have multiple framing terms to reflect varying degrees of match.
+
+There can be multiple entry code framing overlays within a single bundle, one for each specific external context source (such as a single ontology or vocabulary aka `frame_id`). There can be only one overlay per unique `frame_id`. 
+
+For each entry code of each attribute there can only be one skos:exactMatch, but there may be additional framing terms for the same entry code (e.g. skos:closeMatch).
+
+```json
+{
+  "capture_base": "Etszl9LgLUjllI950rd2lO6rF5-BP_jGzXGBPkFZCZFA",
+  "type": "spec/overlays/entry_code_framing/1.0",
+  "framing_metadata": {
+    "frame_id": "SNOMEDCT",
+    "frame_label": "Systematized Nomenclature of Medicine Clinical Terms",
+    "frame_location": "https://bioportal.bioontology.org/ontologies/SNOMEDCT",
+    "frame_version": "2023AA"
+  },
+  "entry_code_framing": {
+    "Sample type": {
+      "BLD001": {
+        "http://purl.bioontology.org/ontology/SNOMEDCT/258581004": {
+          "predicate_id": "skos:closeMatch",
+          "framing_justification": "semapv:ManualMappingCuration"
+        }
+      },
+      "BLD002": {
+        "http://purl.bioontology.org/ontology/SNOMEDCT/441510007": {
+          "predicate_id": "skos:broadMatch",
+          "framing_justification": "semapv:ManualMappingCuration"
+        }
+      },
+      "BLD003": {
+        "http://purl.bioontology.org/ontology/SNOMEDCT/441510007": {
+          "predicate_id": "skos:broadMatch",
+          "framing_justification": "semapv:ManualMappingCuration"
+        }
+      },
+      "BLD004": {
+        "http://purl.bioontology.org/ontology/SNOMEDCT/441510007": {
+          "predicate_id": "skos:broadMatch",
+          "framing_justification": "semapv:ManualMappingCuration"
+        }
+      },
+      "BLD005": {
+        "http://purl.bioontology.org/ontology/SNOMEDCT/441510007": {
+          "predicate_id": "skos:broadMatch",
+          "framing_justification": "semapv:ManualMappingCuration"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Unit Framing Overlay
+
+Unit Framing Overlays focus on the units used in schemas, mapping them to standardized units in external vocabularies like UCUM. Precision is paramount here, and only SKOS is permitted to ensure that quantitative data remains accurate and reliable.
+
+There can be multiple unit framing overlays within a single bundle, one for each specific external context source (such as a single unit ontology or vocabulary aka `frame_id`). There can be only one overlay per unique `frame_id`. 
+
+For each unique unit that appears in the schema there can be only one `unit_framing` term. This term must be skos:exactMatch and only skos:exactMatch is allowed (no other skos terms). This is because units are often associated with quantitative data and it is necessary to preserve accuracy and to use units reported to transform data.
+
+```
+{
+  "capture_base": "Etszl9LgLUjllI950rd2lO6rF5-BP_jGzXGBPkFZCZFA",
+  "type": "spec/overlays/unit_framing/1.0",
+  "framing_metadata": {
+    "frame_id": "UCUM",
+    "frame_label": "",
+    "frame_location": "https://ucum.org/",
+    "frame_version": ""
+  },
+  "unit_framing": {
+    "mg/dL": {
+      "term_id": "mg/dL",
+      "predicate_id": "skos:exactMatch",
+      "framing_justification": "semapv:ManualMappingCuration"
+    }
+  }
+}
+```
+
+#### Rules for framing overlays
+* For each framing overlay there must be a `frame_id`
+* Within each overlay framing type (attribute, unit or entry_code) each `frame_id` must be unique.
+* Not every term must be framed
+* For each attribute or entry_code framing there can be only one skos:exactMatch (or equivalent term in another mapping vocabulary) per term.
+* For unit framing, each unique unit used in a schema can be framed only once.
+* For unit framing, each unit can only be framed using skos:exactMatch.
+
+#### Predicate_id
+Recommended skos terms for vocabulary mapping
+
+Source: [SKOS mapping vocabulary](https://www.w3.org/TR/2009/REC-skos-reference-20090818/#mapping))
+
+#### Framing_justification
+Recommended semapv terms selected by the SSSOM standard for framing justification.
+
+Source: SEMAPV: [A Vocabulary for Semantic Mappings](https://github.com/mapping-commons/semantic-mapping-vocabulary) and [use in SSSOM](https://mapping-commons.github.io/sssom/mapping_justification/)
 
 ```json
 TODO

--- a/docs/v1.1.0-rc.md
+++ b/docs/v1.1.0-rc.md
@@ -762,12 +762,13 @@ For each unique unit that appears in the schema there can be only one `unit_fram
 #### Predicate_id
 Recommended skos terms for vocabulary mapping
 
-Source: [SKOS mapping vocabulary](https://www.w3.org/TR/2009/REC-skos-reference-20090818/#mapping))
+Source: [SKOS mapping vocabulary](https://www.w3.org/TR/2009/REC-skos-reference-20090818/#mapping)
 
 #### Framing_justification
 Recommended semapv subclasses of Matching Processes.
 
-Source: SEMAPV: [A Vocabulary for Semantic Mappings: Matching Processes subclasses]([https://github.com/mapping-commons/semantic-mapping-vocabulary](https://w3id.org/semapv/vocab/Matching)).
+Source: SEMAPV: [A Vocabulary for Semantic Mappings: Matching Processes subclasses](https://mapping-commons.github.io/semantic-mapping-vocabulary/#matchingprocess).
+
 ```json
 TODO
 ```

--- a/docs/v1.1.0-rc.md
+++ b/docs/v1.1.0-rc.md
@@ -765,10 +765,9 @@ Recommended skos terms for vocabulary mapping
 Source: [SKOS mapping vocabulary](https://www.w3.org/TR/2009/REC-skos-reference-20090818/#mapping))
 
 #### Framing_justification
-Recommended semapv terms selected by the SSSOM standard for framing justification.
+Recommended semapv subclasses of Matching Processes.
 
-Source: SEMAPV: [A Vocabulary for Semantic Mappings](https://github.com/mapping-commons/semantic-mapping-vocabulary) and [use in SSSOM](https://mapping-commons.github.io/sssom/mapping_justification/)
-
+Source: SEMAPV: [A Vocabulary for Semantic Mappings: Matching Processes subclasses]([https://github.com/mapping-commons/semantic-mapping-vocabulary](https://w3id.org/semapv/vocab/Matching)).
 ```json
 TODO
 ```


### PR DESCRIPTION
Addressed comments from https://github.com/the-human-colossus-foundation/oca-spec/pull/63

Tables for predicate_id and framing_justification removed and links replaced.

Capital letters removed in all variable names (of the OCA spec).

Removed digest from all framing examples.

I think this is the correct file now.