### PR TITLE
Fix the JSON errors in the bundle example

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -931,7 +931,7 @@ with the specification.
         "i": "Text",
         "passed": "Boolean"
       },
-      "classification": "",
+      "classification": ""
     },
     "overlays": [
       {
@@ -943,7 +943,7 @@ with the specification.
               "digest": "Schema digest",
               "i": "Credential Issuee",
               "passed": "Passed"
-          },
+          }
       },
       {
           "digest": "ED6Eio9KG2jHdFg3gXQpc0PX2xEI7aHnGDOpjU6VBfjs",
@@ -984,9 +984,11 @@ with the specification.
           "description": "Entrance credential",
           "name": "Entrance credential"
       }
-
+    ]
+  }
 }
 ```
+
 _Example 20. Code snippet for an OCA Bundle._
 
 ## Deterministic Identifier


### PR DESCRIPTION
Fixes some typos in the OCA Bundle JSON example 20.

I think that the `"bundle"` item should be removed to not break compatibility with the existing bundles that are used in the world. It adds little to no value, and breaks (AFAIK) all existing implementations.

If we remove that, then the only change from what we've been using is the addition of the `"v"` and `"digest"` items at the root of the object -- an addition that shouldn't break any existing implementations.

Let me know if you would like `bundle` also removed.

Also, just to go in record -- I would really like to have the "base-64 length of the bundle" removed from `v`. While `v` as a semver is crucial, the length is not needed and a pain for developers.
